### PR TITLE
Remove dependence on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ Pi-hole stats module for MagicMirror<sup>2</sup>
 
 - [MagicMirror<sup>2</sup>](https://github.com/MichMich/MagicMirror)
 - [Pi-hole](https://pi-hole.net)
+- Axios
 
 ## Installation
 
 1. Clone this repo into `~/MagicMirror/modules` directory.<br>
   `git clone https://github.com/sheyabernstein/MMM-pihole-stats.git`
-2. Configure your `~/MagicMirror/config/config.js`:
+2. Install Axios dependency:
+```
+cd MMM-pihole-stats
+npm install
+```
+3. Configure your `~/MagicMirror/config/config.js`:
 
 Here is an example entry for `config.js`.
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,5 @@
-
-var request = require('request');
-var NodeHelper = require("node_helper");
+const NodeHelper = require("node_helper");
+const axios = require('axios');
 
 module.exports = NodeHelper.create({
 
@@ -25,17 +24,28 @@ module.exports = NodeHelper.create({
 		}
 	},
 
-	getPiholeData: function (url, port, notification) {
+	getPiholeData: async function (url, port, notification) {
 		var self = this;
-		request({ url: url, port: port, headers: { 'Referer': url }, method: 'GET' }, function (error, response, body) {
-			if (!error && response.statusCode == 200) {
-				self.sendSocketNotification(notification, JSON.parse(body));
-			} else {
-				console.error(self.name + ' ERROR:', error);
-				console.error(self.name + ' statusCode:', response.statusCode);
-				console.error(self.name + ' body:', body);
-			}
-		});
+
+		// Add port to the proper location
+		var splitUrl = url.split("/");
+		if(url.startsWith("http")) {
+			splitUrl[2] = splitUrl[2] + ":" + port;
+		}
+		else {
+			splitUrl[0] = splitUrl[0] + ":" + port;
+		}
+		url = splitUrl.join("/");
+
+		try {
+			console.log(this.name + ": url: " + url);
+			var html = await axios.get(url);
+			this.sendSocketNotification(notification, html.data);
+		}
+		catch (e) {
+			console.log(this.name + " error: " + e);
+            console.error(e);
+        }
 	}
 
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mmm-pihole-stats",
+  "version": "1.0.0",
+  "description": "pihole stats for Magic Mirror",
+  "main": "MMM-pihole-stats.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "",
+  "dependencies": {
+    "axios": "^0.24.0"
+  }
+}


### PR DESCRIPTION
`request` has been deprecated, so we shouldn't use it. Also, on newer versions of MM it causes a black screen.