### PR TITLE
Fix for issue #21.

### DIFF
--- a/MMM-pihole-stats.js
+++ b/MMM-pihole-stats.js
@@ -25,7 +25,7 @@ Module.register('MMM-pihole-stats', {
 	},
 
 	formatInt: function (n) {
-		return parseInt(n).toLocaleString();
+		return n.toLocaleString();
 	},
 
 	formatFloat: function (n) {


### PR DESCRIPTION
Removed the 'parseInt' function call at line 28 to address improper integer formatting after testing on local machines. parseInt was only displaying digits before the comma(s) used as numerical separators for each metric being displayed. This is the intended behavior of the parseInt() function according to: https://devdocs.io/javascript/global_objects/parseint