### PR TITLE
Use fetch, remove port config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+
+node_modules
+package-lock.json

--- a/MMM-pihole-stats.js
+++ b/MMM-pihole-stats.js
@@ -10,7 +10,6 @@ Module.register("MMM-pihole-stats", {
     defaults: {
         apiKey: "",
         apiURL: "http://pi.hole/admin/api.php",
-        port: 80,
         showSources: true,
         sourcesCount: 10,
         showSourceHostnameOnly: true,

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Without `config.showSources` enabled:
 
 1. Clone this repo into `~/MagicMirror/modules` directory.<br>
   `git clone https://github.com/sheyabernstein/MMM-pihole-stats.git`
-2. Obtain an API token from your PiHole installation by navigating to [http://pi.hole/admin/settings.php?tab=api](http://pi.hole/admin/settings.php?tab=api) and clicking `Show API token`
-3. Configure your `~/MagicMirror/config/config.js`
+2. Run `npm install` in the cloned module directory
+3. Obtain an API token from your PiHole installation by navigating to [http://pi.hole/admin/settings.php?tab=api](http://pi.hole/admin/settings.php?tab=api) and clicking `Show API token`
+4. Configure your `~/MagicMirror/config/config.js`
+
 
 Here is an example entry for `config.js`:
 
@@ -37,6 +39,8 @@ Here is an example entry for `config.js`:
 }
 ```
 
+> Feb 27, 2024 update: This module now requires `npm install` when installing.
+
 > Sep 27, 2020 update: Configuring the Pi-hole server to allow CORS is no longer needed.
 
 ## Configuration Options
@@ -44,7 +48,6 @@ Here is an example entry for `config.js`:
 | **Option**               | **Default**                    | **Description**                                                                                                                     |
 |--------------------------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `apiURL`                 | `http://pi.hole/admin/api.php` | URL to Pi-hole admin, including HTTP protocol                                                                                       |
-| `port`                   | `80`                           | Pi-hole admin port                                                                                                                  |
 | `apiToken`               |                                | API Token from Pi-hole (required for `showSources`)                                                                                 |
 | `showSources`            | `true`                         | Show request sources (clients)                                                                                                      |
 | `sourcesCount`           | `10`                           | Number of returned entries for `showSources`                                                                                        |

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,5 @@
 const Log = require("logger");
-const fetch = require("node-fetch");
+const request = require("request");
 const NodeHelper = require("node_helper");
 
 module.exports = NodeHelper.create({
@@ -54,10 +54,6 @@ module.exports = NodeHelper.create({
 
         const url = new URL(config.apiURL);
 
-        if (config.port) {
-            url.port = config.port;
-        }
-
         url.search = new URLSearchParams(params).toString();
         return url.toString();
     },
@@ -68,15 +64,16 @@ module.exports = NodeHelper.create({
             headers = { Referer: url };
 
         this.sendSocketNotification("LOADING_PIHOLE_URL", url);
-        fetch(url, { headers: headers }).then(
-            (response) => {
-                response.json().then((data) => {
-                    self.sendSocketNotification(notification, data);
-                });
-            },
-            (error) => {
+
+        request({ url, headers, json: true }, (error, response, data) => {
+Log.info('url', url)
+//Log.info('response', response.statusCode)
+//Log.info('data', data)
+            if (error) {
                 Log.error(self.name + " ERROR:", error);
-            },
-        );
+            } else {
+                self.sendSocketNotification(notification, data);
+            }
+        });
     },
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "MMMM-pihole-stats",
+  "version": "1.0.0",
+  "description": "Pi-hole stats module for MagicMirror2",
+  "main": "MMM-pihole-stats.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sheyabernstein/MMM-pihole-stats.git"
+  },
+  "keywords": [
+    "MagicMirror",
+    "Module",
+    "Pi-Hole"
+  ],
+  "author": "Sheya Bernstein",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sheyabernstein/MMM-pihole-stats/issues"
+  },
+  "homepage": "https://github.com/sheyabernstein/MMM-pihole-stats#readme",
+  "dependencies": {
+    "request": "^2.81.0"
+  }
+}


### PR DESCRIPTION
This MR switches to use `fetch` because`node-fetch` was removed from MagicMirror base.

It also removes the `port` config variable.

Fixes #30 