### PR TITLE
Fix clients column not displaying when hostname is unconfigured

### DIFF
--- a/MMM-pihole-stats.js
+++ b/MMM-pihole-stats.js
@@ -90,8 +90,8 @@ Module.register("MMM-pihole-stats", {
 
             // Iterate over the array of client objects.
             this.top_sources.forEach((client) => {
-                let displayName = client.name;
-                if (this.config.showSourceHostnameOnly) {
+                let displayName = client.name || client.ip;
+                if (this.config.showSourceHostnameOnly && client.name) {
                     displayName = client.name.split("|")[0];
                 }
 


### PR DESCRIPTION
Resolves #58 - Clients without configured hostnames in Pi-hole now display their IP address instead of being blank.

### Changes
- Updated display logic to use hostname if available, otherwise fall back to IP address
- Added safety check to only split hostname when it actually exists (prevents errors)
- This handles Pi-hole instances where local devices don't have DNS reverse lookups or hostname mappings configured

The Pi-hole API returns client objects with both `name` (hostname) and `ip` (address) properties. When a device doesn't have a hostname configured, `name` is an empty string, which previously resulted in blank display cells. Now the code falls back to displaying the `ip` property.
